### PR TITLE
Change wordpress version from latest to 5.2.4

### DIFF
--- a/wordpress/Dockerfile
+++ b/wordpress/Dockerfile
@@ -1,4 +1,4 @@
-FROM wordpress:latest
+FROM wordpress:5.2.4
 
 # install WP-CLI and rsync
 RUN apt-get update \


### PR DESCRIPTION
Wordpress 5.3 breaks some stuff in the wordpress container. Fix the version at 5.2.4 for now.