### PR TITLE
Fix dev environment with no frontend .env file

### DIFF
--- a/frontend/src/server.js
+++ b/frontend/src/server.js
@@ -1,6 +1,6 @@
 const express = require('express');
 const next = require('next');
-const dotenv = require('dotenv');
+const dotenv = require('dotenv-defaults');
 dotenv.config();
 
 const bodyParser = require('body-parser');


### PR DESCRIPTION
Without this fix, attempting to run the default developer configuration will give you undefined values for dotenv variables. Fix this by properly importing dotenv-defaults instead.