### PR TITLE
Cleanup README for secrets + dev setup cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,69 +30,65 @@
 
 ## Installation
 
-To spin up the whole application for the first time:
+To spin up the whole application for the first time in dev mode:
 <br/>
 **Make sure to install the latest version of [Docker](https://www.docker.com/) and Python 3.5 or greater before continuing**
 ```sh
 $ git clone https://github.com/nicer00ster/devgulp.git
 $ cd devgulp
-$ run.py prod generate_secrets
-...
-$ run.py prod generate_dhparam
-... #this may take a while
-$ run.py prod up
-```
-
-You may need to wait a while for the dhparam certificate to be generated. This is a one-time process and should not need to be repeated.
-
-Connect to http://localhost and confirm it is working.
-
-If you need to run on different host ports, edit the appropriate port lines in docker-compose.yaml. The ports are declared as \<HostPort\>:\<ContainerPort\>.
-
-To shut down the application:
-```sh
-$ run.py prod down
-```
-
-
-Instructions on how to get a local development copy up & running:
-```sh
-# Initial installation
+# Start the docker containers
+$ run.py dev up
+# Start the next server
 $ cd devgulp/frontend/src
 $ npm install
-# Run dev frontend
 $ npm run dev
 ```
 
-Set up WordPress instance:
+Head to http://localhost:3000 and confirm everything is working. If the page loads, but you do not see any posts, head to http://localhost:8000 to see if WordPress is running. If your Docker instance is not running on localhost, you will need to modify `HOST_URL` in `.env` in the root directory and `API_URL` in your `frontend/src/.env` file for development. If you need to run on different host ports (as may be the case when using docker-machine or older versions of Docker Toolkit), edit the appropriate port lines in docker-compose.yml. The ports are declared as \<HostPort\>:\<ContainerPort\>.
+
+PHPMyAdmin is available at http://localhost:8080 for development. The default login for the dev environment is username: `wordpress` and password: `wordpress`
+
+> Note for Windows Docker users: You may need to enable shared drives to properly mount functions.php in the dev config. See https://docs.docker.com/docker-for-windows/#shared-drives for more details.
+
+To shut down the application:
+```sh
+# Close the foreground npm process (e.g. Ctrl + C)
+# ...
+# Shut down the docker containers
+$ run.py dev down
+```
+
+Dev commands:
 <br />
 ```sh
-# To start up initially
-
-$ cd devgulp
+# Rebuild the wordpress container if there are changes, and start it (as well as the db + phpmyadmin)
 $ run.py dev up
-
 # Using the dev compose config, changes to functions.php will be automatically reflected in WordPress
-# To update other files:
-$ run.py dev up
+# To update other files, run the above command.
 
 # To Tear Down WITHOUT destroying database data
-
 $ run.py dev down
 
 # To Tear Down and destroy database data
 # Warning! This will delete everything you've done on your WordPress instance, including all posts and user accounts.
 # This is irreversible.
-
 $ run.py dev destroy
 ```
 
-Head to http://localhost:8000 and confirm WordPress is running. If your Docker instance is not running on localhost, you will need to modify `HOST_URL` in `.env` in the root directory and `API_URL` in your `frontend/src/.env` file for development.
+## Staging
 
-> Note for Windows Docker users: You may need to enable shared drives to properly mount functions.php in the dev config. See https://docs.docker.com/docker-for-windows/#shared-drives for more details.
+```sh
+$ run.py prod generate_secrets
+... #enter values for the various secrets or leave blank to generate random values
+$ run.py prod generate_dhparam
+... #this may take a while
+$ run.py prod up
+```
 
-## Usage
-Placeholder for usage section;
+You may need to wait a while for the DH parameters to be generated. This is a one-time process and should not need to be repeated.
+
+Connect to http://localhost and confirm it is working.
+
 
 ## Testing
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -50,7 +50,7 @@ services:
       WORDPRESS_ADMIN_EMAIL: fake@example.com
       JWT_AUTHENTICATION_SECRET_KEY: secretkey
     volumes:
-      - ./wordpress/src/wp-includes/functions.php:/var/www/html/wp-includes/functions.php:ro
+      - ./wordpress/src/wp-includes/functions.php:/opt/mount/functions.php:ro
     ports:
       - '8000:80'
     networks:

--- a/run.py
+++ b/run.py
@@ -96,6 +96,10 @@ def clear_secrets():
         print('No secrets found')
 
 def generate_dhparam():
+    """
+    Generates a 4096-bit dhparam key to use for DH key exchange. This is required for SSL to function.
+    For more info: https://security.stackexchange.com/questions/94390/whats-the-purpose-of-dh-parameters
+    """
     root_path = Path(__file__).resolve().parent
     run_cmd(['docker', 'run', '--rm', '-v', '{}:/export'.format(root_path), 'frapsoft/openssl', 'dhparam', '-out', '/export/dhparam.pem', '4096'])
     dhparam_file = root_path / 'dhparam.pem'

--- a/wordpress/Dockerfile
+++ b/wordpress/Dockerfile
@@ -1,8 +1,8 @@
-FROM wordpress:5.2.4
+FROM wordpress:5.2
 
 # install WP-CLI and rsync
 RUN apt-get update \
-  && apt-get install -y sudo less mariadb-client rsync \
+  && apt-get install -y sudo less mariadb-client \
   && rm -rf /var/lib/apt/lists/*
 RUN curl -o /bin/wp-cli.phar https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar
 COPY wp-su.sh /bin/wp

--- a/wordpress/docker-entrypoint.sh
+++ b/wordpress/docker-entrypoint.sh
@@ -179,9 +179,12 @@ EOPHP
 	fi
 
 	# Copy over the application files to ensure they are the latest version
-	rsync -rI --exclude=/wp-includes/functions.php /opt/app/. /var/www/html/
-	if [[ -w /var/www/html/wp-includes/functions.php ]]; then
-		cp -f /opt/app/wp-includes/functions.php /var/www/html/wp-includes/functions.php
+	if [[ -L /var/www/html/wp-includes/functions.php ]]; then
+		rm /var/www/html/wp-includes/functions.php
+	fi
+	cp -rf /opt/app/. /var/www/html/
+	if [[ -e /opt/mount/functions.php ]]; then
+		ln -sf /opt/mount/functions.php /var/www/html/wp-includes/functions.php
 	fi
 
 	# If the instance has not yet been configured, copy the plugins and API and run the wordpress install


### PR DESCRIPTION
- Rewrote the installation section of the README to actually make sense
- Added a missing docstring in run.py
- Change Wordpress pin from 5.2.4 to 5.2.x (5.2.5 was released with security fixes on 12/9/19)
- Remove rsync dependency from the wordpress container