### PR TITLE
Bugfix/fix entrypoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,3 +91,6 @@ typings/
 # secrets
 /secrets
 /proxy/dhparam.pem
+
+# venv
+.venv

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -51,6 +51,7 @@ services:
       JWT_AUTHENTICATION_SECRET_KEY: secretkey
     volumes:
       - ./wordpress/src/wp-includes/functions.php:/opt/mount/functions.php:ro
+      - wp_data:/var/www/html
     ports:
       - '8000:80'
     networks:
@@ -60,3 +61,4 @@ networks:
   wpsite:
 volumes:
   db_data:
+  wp_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,6 +54,8 @@ services:
       WORDPRESS_ADMIN_PASSWORD_FILE: /run/secrets/wp_admin_password
       WORDPRESS_ADMIN_EMAIL: fake@example.com
       JWT_AUTHENTICATION_SECRET_KEY_FILE: /run/secrets/jwt_auth_key
+    volumes:
+      - wp_data:/var/www/html
     networks:
       - wpsite
       - proxysite
@@ -102,6 +104,7 @@ networks:
 
 volumes:
   db_data:
+  wp_data:
 
 secrets:
   db_root_password:


### PR DESCRIPTION
Finally fix the container restart persistence issue. This ended up being a lot easier than what I originally thought when I finally diagnosed the issue.

While restarting the container is solid now, it may break if new versions of wordpress change the base files. The pinned version should be ok for now.